### PR TITLE
remove title metadata

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -1,3 +1,2 @@
 name: tutorials
-title: Session Storage with Couchbase
 version: 'master'


### PR DESCRIPTION
The tutorial's title is derived from the h1 in the `.adoc` file.