### PR TITLE
remove :page-aliases: attribute

### DIFF
--- a/modules/profile-store/pages/install.adoc
+++ b/modules/profile-store/pages/install.adoc
@@ -1,5 +1,4 @@
 = How to Setup and Configure a Couchbase Cluster
-:page-aliases: tutorials:session-storage-tutorial:install
 
 To use Couchbase as a session store, you must first install Couchbase (somewhere). Then, you must set up the Couchbase cluster. Finally, you'll need to create a bucket to store the session data.
 

--- a/modules/profile-store/pages/java.adoc
+++ b/modules/profile-store/pages/java.adoc
@@ -1,5 +1,4 @@
 = Using Couchbase Server to Build a User Profile Store
-:page-aliases: tutorials:profile-store-tutorial:java
 
 == Overview
 


### PR DESCRIPTION
`:page-aliases:` is used for page redirects. It is used for the session-storage because it was previously at a different location.

But given profile store is a new tutorial we don't need it.